### PR TITLE
Switch to ECDSA signing

### DIFF
--- a/android/src/main/java/com/travelunion/flutter_biometrics/FlutterBiometricsPlugin.java
+++ b/android/src/main/java/com/travelunion/flutter_biometrics/FlutterBiometricsPlugin.java
@@ -17,7 +17,7 @@ import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
-import java.security.spec.RSAKeyGenParameterSpec;
+import java.security.spec.ECGenParameterSpec;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -114,13 +114,13 @@ public class FlutterBiometricsPlugin implements MethodCallHandler, FlutterPlugin
       try {
         deleteBiometricKey();
 
-        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_RSA,
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC,
             KEYSTORE);
 
         KeyGenParameterSpec keyGenParameterSpec = new KeyGenParameterSpec.Builder(KEY_ALIAS,
-            KeyProperties.PURPOSE_SIGN).setDigests(KeyProperties.DIGEST_SHA256)
-                .setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1)
-                .setAlgorithmParameterSpec(new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4))
+            KeyProperties.PURPOSE_SIGN)
+                .setDigests(KeyProperties.DIGEST_SHA256)
+                .setAlgorithmParameterSpec(new ECGenParameterSpec("secp256r1"))
                 .setUserAuthenticationRequired(true)
                 .build();
 
@@ -170,7 +170,7 @@ public class FlutterBiometricsPlugin implements MethodCallHandler, FlutterPlugin
 
       PrivateKey privateKey = (PrivateKey) keyStore.getKey(KEY_ALIAS, null);
 
-      Signature signature = Signature.getInstance("SHA256withRSA");
+      Signature signature = Signature.getInstance("SHA256withECDSA");
       signature.initSign(privateKey);
 
       CryptoObject cryptoObject = new CryptoObject(signature);

--- a/ios/Classes/SwiftFlutterBiometricsPlugin.swift
+++ b/ios/Classes/SwiftFlutterBiometricsPlugin.swift
@@ -98,7 +98,7 @@ public class SwiftFlutterBiometricsPlugin: NSObject, FlutterPlugin {
         let query = [
             kSecClass as String: kSecClassKey,
             kSecAttrApplicationTag as String: keyTag,
-            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
             kSecReturnRef as String: true,
             kSecUseOperationPrompt as String: reason
         ] as [String : Any]
@@ -111,7 +111,7 @@ public class SwiftFlutterBiometricsPlugin: NSObject, FlutterPlugin {
             let privateKey = item as! SecKey
             
             let decodedData = NSData.init(base64Encoded: payload, options: [])
-            let signature = SecKeyCreateSignature(privateKey, SecKeyAlgorithm.rsaSignatureMessagePKCS1v15SHA256, decodedData!, nil)
+            let signature = SecKeyCreateSignature(privateKey, SecKeyAlgorithm.ecdsaSignatureMessageX962SHA256, decodedData!, nil)
             
             if (signature != nil) {
                 let signatureString = NSData(data: signature! as Data).base64EncodedString(options: [])
@@ -170,8 +170,8 @@ public class SwiftFlutterBiometricsPlugin: NSObject, FlutterPlugin {
         let keyTag = self.getBiometricKeyTag()
         let query = [
             kSecClass as String: kSecClassKey,
-            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
-            kSecAttrKeySizeInBits as String: 2048,
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+            kSecAttrKeySizeInBits as String: 256,
             kSecPrivateKeyAttrs as String: [
                 kSecAttrIsPermanent as String: true,
                 kSecUseAuthenticationUI as String: kSecUseAuthenticationUIAllow,
@@ -201,7 +201,7 @@ public class SwiftFlutterBiometricsPlugin: NSObject, FlutterPlugin {
         let query = [
             kSecClass as String: kSecClassKey,
             kSecAttrApplicationTag as String: keyTag,
-            kSecAttrKeyType as String: kSecAttrKeyTypeRSA
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom
         ] as [String : Any]
         
         return SecItemDelete(query as CFDictionary)
@@ -216,8 +216,11 @@ public class SwiftFlutterBiometricsPlugin: NSObject, FlutterPlugin {
         let result = NSMutableData()
         
         let encodingLength: Int = (publicKey.count + 1).encodedOctets().count
-        let OID: [CUnsignedChar] = [0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86,
-                                    0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00]
+        let OID: [CUnsignedChar] = [
+            0x30, 0x13,
+            0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01,
+            0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07
+        ]
         
         var builder: [CUnsignedChar] = []
         
@@ -248,7 +251,7 @@ public class SwiftFlutterBiometricsPlugin: NSObject, FlutterPlugin {
         let query = [
             kSecClass as String: kSecClassKey,
             kSecAttrApplicationTag as String: keyTag,
-            kSecAttrKeyType as String: kSecAttrKeyTypeRSA
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom
         ] as [String : Any]
         
         let status = SecItemCopyMatching(query as CFDictionary, nil)

--- a/lib/flutter_biometrics.dart
+++ b/lib/flutter_biometrics.dart
@@ -17,7 +17,7 @@ const String CHANNEL_NANME = 'flutter_biometrics';
 class FlutterBiometrics {
   static const MethodChannel _channel = const MethodChannel(CHANNEL_NANME);
 
-  /// Creates SHA256 RSA key pair for signing using biometrics
+  /// Creates SHA256 ECDSA key pair (secp256r1) for signing using biometrics
   ///
   /// Will create a new keypair each time method is called
   ///


### PR DESCRIPTION
## Summary
- switch Android key generation and signing to ECDSA P‑256
- switch iOS key generation and signing to ECDSA P‑256
- update Dart API docs to note the new algorithm

## Testing
- `dart format lib/flutter_biometrics.dart` *(fails: `dart: command not found`)*